### PR TITLE
[setting.py] and [urls.py] modified.

### DIFF
--- a/glean/glean/settings.py
+++ b/glean/glean/settings.py
@@ -119,8 +119,6 @@ DRAGON_URL = 'http://127.0.0.1:9999/'
 # please write your public ip and open port num(but "9999")
 #DRAGON_URL = 'http://:/'
 
-LOGIN_REDIRECT_URL = '/chat/'
-
 LOGIN_URL = '/login'
 LOGOUT_URL = '/logout'
 LOGIN_REDIRECT_URL = '/base'

--- a/glean/glean/urls.py
+++ b/glean/glean/urls.py
@@ -18,7 +18,6 @@ from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required
 
 urlpatterns = [
-    url(r'^chat', login_required(TemplateView.as_view(template_name='index.html')), name='home'),
     url(r'^base', login_required(TemplateView.as_view(template_name='base.html')), name='base'),
     url(r'^top', login_required(TemplateView.as_view(template_name='toppage.html')), name='top'),
     url(r'^login', 'django.contrib.auth.views.login', kwargs={'template_name': 'login.html'}, name='login'),


### PR DESCRIPTION
[setting.py]
There is a rogue substitution "LOGIN_REDIRECT_URL = '/chat'" that re-substitution after.
Removed.

[urls.py]
Also, there is a rogue routing about '/chat'.
Removed.