### PR TITLE
fixed login display of style.css.(issue #12)

### DIFF
--- a/glean/static/materialize/css/style.css
+++ b/glean/static/materialize/css/style.css
@@ -158,9 +158,7 @@ margin-top:2%;
 }
 
 .sign-up{
-    position:fixed;
-    top:72%;
-    left:25%;
+    left:50%;
     z-index:1;
 }
 


### PR DESCRIPTION
In 161～163 line of style.css,
deleted "position" and "top"  of .sign-up class, and fixed "left" because adjusted login form.